### PR TITLE
v1.7.0: Updates for Python 3.10

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,3 +16,4 @@ v1.6.2, 2018-08-24 -- Add base_canonical variable for use in custom templates
 v1.6.3, 2019-05-08 -- Update the copyright year in the footer
 v1.6.4, 2021-10-20 -- Update pyyaml and gitpython
 v1.6.5, 2021-10-20 -- GitPython 3.1.20 (works with more python versions)
+v1.7.0, 2023-01-30 -- Update code and dependencies to work with Python 3.10

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ assert sys.version_info >= (
 
 setup(
     name="ubuntudesign.documentation-builder",
-    version="1.6.5",
+    version="1.7.0",
     author="Canonical webteam",
     author_email="robin+pypi@canonical.com",
     url="https://github.com/ubuntudesign/documentation-builder",
@@ -30,14 +30,14 @@ setup(
     long_description=open("README.rst").read(),
     install_requires=[
         "GitPython==3.1.20",
-        "Jinja2==2.8",
-        "Markdown==2.6.6",
+        "Jinja2==3.1.2 ",
+        "markdown==2.6.11",
         "mdx-anchors-away==1.0.1",
         "mdx-foldouts==1.0.0",
         "python-frontmatter==0.2.1",
-        "pygments==2.2.0",
+        "pygments==2.4.0",
         "PyYAML==6.0",
-        "beautifulsoup4==4.5.1",
+        "beautifulsoup4==4.11.1",
         "markdown_urlize==0.2.0",
     ],
     setup_requires=["pytest-runner"],

--- a/ubuntudesign/documentation_builder/operations.py
+++ b/ubuntudesign/documentation_builder/operations.py
@@ -1,7 +1,7 @@
 # Core modules
 import re
 import tempfile
-from collections import Mapping
+from collections.abc import Mapping
 from copy import deepcopy
 from glob import glob, iglob
 from os import makedirs, path


### PR DESCRIPTION
Updates for Python 3.10

QA
--

In docs.ubuntu.com, in the `requirements.txt` file, replace the `ubuntudesign.documentation-builder` line with:

```
git+https://github.com/canonical/documentation-builder@python-3.10-updates#egg=ubuntudesign.documentation-builder
```

Now run `dotrun clean` and then `dotrun build`. Check the build succeeds.

Then push up that code, temporarily, to your branch and check the CI succeeds.

Then we can merge this, at which point you need to replace the line above with `ubuntudesign.documentation-builder==1.7.0`